### PR TITLE
Proposed change to support -headless version of serve macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ The `serve` macro:
 
 * Is safe to run multiple times.
 * Finds a free port if you do not specify one.
-* Opens up a web browser to view your handler.
+* Opens up a web browser to view your handler, or if you don't want
+  this, call the `serve-headless` macro instead.
 * Automatically takes into account any changes made to your
   handler.
 * Wraps your handler in the `wrap-stacktrace` middleware.
 * Ensures that the `swank.core/break` function works correctly inside
   your handler.
+
 
 ## Example
 
@@ -36,4 +38,4 @@ The `serve` macro:
 
 Include the following dependency in your Leiningen project file:
 
-    [ring-serve "0.1.0"]
+    [ring-serve "0.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-serve "0.1.0"
+(defproject ring-serve "0.1.1"
   :description "Ring development web server"
   :dependencies [[org.clojure/clojure "1.2.0"]
                  [ring/ring-devel "0.3.5"]

--- a/src/ring/util/serve.clj
+++ b/src/ring/util/serve.clj
@@ -58,14 +58,15 @@
         port      (.getPort connector)]
     (str "http://" host ":" port)))
 
-(defn serve* [handler & [port]]
+(defn serve* [handler & [port headless?]]
   (stop-server)
   (reset! jetty-server
           (if port
             (start-server handler port)
             (start-server handler)))
   (println "Started web server on port" (server-port))
-  (browse-url (server-url))
+  (when-not headless?
+    (browse-url (server-url)))
   nil)
 
 (defmacro serve
@@ -76,3 +77,12 @@
   (if (symbol? handler)
     `(serve* (var ~handler) ~port)
     `(serve* ~handler ~port)))
+
+(defmacro serve-headless
+  "Start a development web server that runs the supplied handler in a
+  background thread. Any changes to the handler will be automatically
+  visible on the server.  A web browser is NOT invoked!"
+  [handler & [port]]
+  (if (symbol? handler)
+    `(serve* (var ~handler) ~port true)
+    `(serve* ~handler ~port true)))


### PR DESCRIPTION
Added serve-headless macro, and modified serve\* to take an optional headless? parameter
