### PR TITLE
Migrated to Jetty 7.x (via ring-jetty-adapter 1.1.8).

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,4 +2,4 @@
   :description "Ring development web server"
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [ring/ring-devel "1.0.0"]
-                 [ring/ring-jetty-adapter "1.0.0"]])
+                 [ring/ring-jetty-adapter "1.1.8"]])

--- a/src/ring/util/serve.clj
+++ b/src/ring/util/serve.clj
@@ -1,7 +1,7 @@
 (ns ring.util.serve
   "Development web server for Ring handlers."
   (:import java.net.BindException
-           org.mortbay.log.Logger)
+           org.eclipse.jetty.util.log.Logger)
   (:use clojure.java.browse
         ring.middleware.stacktrace
         ring.middleware.swank
@@ -9,16 +9,12 @@
 
 (deftype SilentLogger []
   Logger
-  (debug [logger msg arg0 arg1])
-  (debug [logger msg th])
   (getLogger [logger name] logger)
-  (info [logger msg arg0 arg1])
-  (isDebugEnabled [logger] false)
-  (warn [logger msg arg0 arg1]))
+  (isDebugEnabled [logger] false))
 
 ;; Stop Jetty logging everything
 (System/setProperty
-  "org.mortbay.log.class"
+  "org.eclipse.jetty.util.log.class"
   "ring.util.serve.SilentLogger")
 
 (defonce jetty-server (atom nil))


### PR DESCRIPTION
Hi James.

This obviously breaks compatibility with Jetty < 6.x. You might want to bump the major (at least minor) release number of ring-serve due to this.

If you'd rather see a pull request which supports both 7.x and 6.x of Jetty I'll be happy to do so.

Regards,
Anders
